### PR TITLE
Add optional (default off) string highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,8 @@ parenthesis, diffs, errors, and warnings. Turn this off with:
 ```vim
 let g:ascetic_accent_colors = 0
 ```
+
+- **String highlighting** is disabled by default, you can turn this on with:
+```vim
+let g:ascetic_highlight_strings = 1
+```

--- a/colors/ascetic.vim
+++ b/colors/ascetic.vim
@@ -15,8 +15,9 @@ let g:colors_name = 'ascetic'
 let s:is_dark = (&background == 'dark')
 
 " Transparency and accent colors are on by default
-let s:ascetic_transparent_bg = get(g:, 'ascetic_transparent_bg', 1)
-let s:ascetic_accent_colors  = get(g:, 'ascetic_accent_colors',  1)
+let s:ascetic_transparent_bg    = get(g:, 'ascetic_transparent_bg',    1)
+let s:ascetic_accent_colors     = get(g:, 'ascetic_accent_colors',     1)
+let s:ascetic_highlight_strings = get(g:, 'ascetic_highlight_strings', 0)
 
 " Init color palette
 let s:col = {}
@@ -98,7 +99,6 @@ call s:h("Cursor",  {"fg": s:bg, "bg": s:fg})
 
 hi! link Constant     Normal
 hi! link Character    Constant
-hi! link String       Constant
 hi! link Boolean      Constant
 hi! link Number       Constant
 hi! link Float        Constant
@@ -111,6 +111,12 @@ hi! link Exception    Constant
 hi! link PreProc      Constant
 hi! link Type         Constant
 hi! link Special      Constant
+
+if s:ascetic_highlight_strings
+  call s:h("String",  {"fg": s:col.medium_gray})
+else
+  hi! link String     Constant
+endif
 
 call s:h("ColorColumn", {"bg": s:darkest_gray})
 hi! link CursorColumn   ColorColumn


### PR DESCRIPTION
Strings represent a kind of "meta syntax" inside most types of code that follows its own rules, so it can be helpful for them to stand out a bit.